### PR TITLE
Clarify test

### DIFF
--- a/test/indexTest.js
+++ b/test/indexTest.js
@@ -19,7 +19,7 @@ describe( "submitData()", () => {
 
   } );
 
-  it( "makes a POST request to /user with a name and email", async () => {
+  it( "makes a POST request to /users with a name and email", async () => {
     let reqBody
     let headers
     nock( 'http://localhost:3000' )


### PR DESCRIPTION
Request should be made to `/users`, but test text says `/user` instead.